### PR TITLE
WIP: support multiple gitlab instances

### DIFF
--- a/gitlab_runner_config.py
+++ b/gitlab_runner_config.py
@@ -94,13 +94,13 @@ class gitlab_client:
                 raise RuntimeError("Error while validating token: {}".format(e.reason))
 
     def register_runner_request(self, data):
-            url = urljoin(self.base_url, "runners")
-            request = Request(url, data=data.encode(), method="POST")
-            response = self.requester.request(request)
-            if response.getcode() == 201:
-                return json.load(response)
-            else:
-                return None
+        url = urljoin(self.base_url, "runners")
+        request = Request(url, data=data.encode(), method="POST")
+        response = self.requester.request(request)
+        if response.getcode() == 201:
+            return json.load(response)
+        else:
+            return None
 
     def register_runner(self, runner_type, tags):
         """Registers a runner and returns its info"""
@@ -115,7 +115,8 @@ class gitlab_client:
 
             runner_data = self.register_runner_request(data)
             if runner_data == None:
-                raise RuntimeError("Registration for {runner_type} failed".format(runner_type))
+                raise RuntimeError("Registration for {runner} failed".format(runner=runner_type))
+            return runner_data
         except HTTPError as e:
             cause = "Error registering runner {runner} with tags {tags}: {reason}".format(
                     runner=runner_type, tags=",".join(tags), reason=e.reason)
@@ -126,7 +127,7 @@ class gitlab_client:
             # no refresh endpoint...delete and re-register
             if token:
                 self.delete_runner(token)
-            return self.register_runner(runner_type, None)
+            return self.register_runner(runner_type, generate_tags(runner_type=runner_type))
         else:
             return None
 
@@ -149,7 +150,7 @@ class gitlab_client:
             if response.getcode() == 204:
                 return True
             else:
-                raise RuntimeError("Deleting runner with id failed")
+                raise RuntimeError("Deleting runner failed")
         except HTTPError as e:
             raise RuntimeError("Error deleting runner: {reason}".format(reason=e.reason)) from e
 

--- a/tests/test_gitlab_client.py
+++ b/tests/test_gitlab_client.py
@@ -1,0 +1,173 @@
+import gitlab_runner_config
+from gitlab_runner_config import gitlab_client
+from gitlab_runner_config import generate_tags
+import pytest
+import unittest
+from unittest.mock import Mock
+from urllib.error import HTTPError
+from urllib.request import Request
+
+@pytest.fixture
+def requester():
+    requester = Mock()
+    return requester
+
+@pytest.fixture
+def gitlab(requester):
+    gitlab = gitlab_client("https://gitlab.example.com", "abcdef", "123456")
+    gitlab.requester = requester
+    return gitlab
+
+class mock_response:
+    def __init__(self, data, code):
+        self.data = data
+        self.code = code
+
+    def getcode(self):
+        return self.code
+    
+    def read(self, amt=0):
+        return self.data
+
+def test_list_runners_empty(requester, gitlab):
+    requester.request.return_value = mock_response("[{}]", 200)
+    ret = gitlab.list_runners()
+    requester.request.assert_called_once()
+    assert requester.request.call_args.args[0].get_full_url() == "https://gitlab.example.com/runners/all"
+    exp = [{}]
+    assert ret == exp
+
+def test_list_runners_error(requester, gitlab):
+    requester.request.return_value = mock_response("[{}]", 500)
+    requester.request.side_effect = HTTPError("https://gitlab.example.com", 500, None, None, None)
+    try:
+        gitlab.list_runners()
+        assert False
+    except RuntimeError as e:
+        assert "Error listing Gitlab repos" in str(e)
+
+def test_list_runners_parse_error(requester, gitlab):
+    requester.request.return_value = mock_response("[{}", 200)
+    try:
+        gitlab.list_runners()
+        assert False
+    except RuntimeError as e:
+        assert "Failed parsing request" in str(e)
+
+def test_list_runners(requester, gitlab):
+    runner_data = '[\
+    {\
+        "active": true,\
+        "description": "test-1",\
+        "id": 6,\
+        "is_shared": false,\
+        "ip_address": "127.0.0.1",\
+        "name": null,\
+        "online": true,\
+        "status": "online"\
+    },\
+    {\
+        "active": true,\
+        "description": "test-2",\
+        "id": 8,\
+        "ip_address": "127.0.0.1",\
+        "is_shared": false,\
+        "name": null,\
+        "online": false,\
+        "status": "offline"\
+    }\
+    ]'
+    requester.request.return_value = mock_response(runner_data, 200)
+    ret = gitlab.list_runners()
+    requester.request.assert_called_once()
+    assert requester.request.call_args.args[0].get_full_url() == \
+        "https://gitlab.example.com/runners/all"
+    exp = [{'active': True, 
+        'description': 
+        'test-1', 'id': 6, 
+        'is_shared': False, 
+        'ip_address': '127.0.0.1', 
+        'name': None, 
+        'online': True, 
+        'status': 'online'}, 
+        {'active': True, 
+        'description': 'test-2', 
+        'id': 8, 
+        'ip_address': '127.0.0.1', 
+        'is_shared': False, 
+        'name': None, 
+        'online': False, 
+        'status': 'offline'}]
+    assert ret == exp
+
+def test_list_runners_filtered(requester, gitlab):
+    filters = {"scope": "shared", "tag_list": ",".join(["host1"])}
+    requester.request.return_value = mock_response("[{}]", 200)
+    gitlab.list_runners(filters)
+    requester.request.assert_called_once()
+    assert requester.request.call_args.args[0].get_full_url() == \
+         "https://gitlab.example.com/runners/all?scope=shared&tag_list=host1"
+
+def test_valid_runner_token_empty(requester, gitlab):
+    requester.request.return_value = mock_response("[{}]", 403)
+    requester.request.side_effect = HTTPError("https://gitlab.example.com", 403, None, None, None)
+    ret = gitlab.valid_runner_token("")
+    requester.request.assert_called_once()
+    assert requester.request.call_args.args[0].get_full_url() == "https://gitlab.example.com/runners/verify"
+    assert not ret
+
+def test_valid_runner_token_valid(requester, gitlab):
+    requester.request.return_value = mock_response("[{}]", 200)
+    ret = gitlab.valid_runner_token("abcdef123456")
+    requester.request.assert_called_once()
+    assert requester.request.call_args.args[0].get_full_url() == "https://gitlab.example.com/runners/verify"
+    assert ret
+
+def test_runner_info(requester, gitlab):
+    requester.request.return_value = mock_response('{\
+        "active": true,\
+        "architecture": null,\
+        "description": "test-1",\
+        "id": 5}', 200)
+    ret = gitlab.runner_info(5)
+    requester.request.assert_called_once()
+    assert requester.request.call_args.args[0].get_full_url() == "https://gitlab.example.com/runners/5"
+    exp = {'active': True, 'architecture': None, 'description': 'test-1', 'id': 5}
+    assert ret == exp
+
+def test_register_runner(requester, gitlab):
+    requester.request.return_value = mock_response('{\
+        "id": "12345",\
+        "token": "6337ff"\
+        }', 201)
+    ret = gitlab.register_runner("batch", generate_tags("batch"))
+    requester.request.assert_called_once()
+    assert requester.request.call_args.args[0].get_full_url() == "https://gitlab.example.com/runners"
+    exp = {'id': '12345', 'token': '6337ff'}
+    assert ret == exp
+
+def test_register_runner_failure(requester, gitlab):
+    requester.request.return_value = mock_response("", 403)
+    try:
+        gitlab.register_runner("batch", generate_tags("batch"))
+        assert False
+    except RuntimeError as e:
+        assert "Registration for batch failed" in str(e)
+    requester.request.assert_called_once()
+    assert requester.request.call_args.args[0].get_full_url() == "https://gitlab.example.com/runners"
+
+def test_delete_runner(requester, gitlab):
+    requester.request.return_value = mock_response('', 204)
+    gitlab.delete_runner("abc123")
+    requester.request.assert_called_once()
+    assert requester.request.call_args.args[0].get_full_url() == "https://gitlab.example.com/runners"
+
+def test_delete_runner_failure(requester, gitlab):
+    requester.request.return_value = mock_response('', 403)
+    try:
+        gitlab.delete_runner("abc123")
+        assert False
+    except RuntimeError as e:
+        assert "Deleting runner failed" in str(e)
+    requester.request.assert_called_once()
+    assert requester.request.call_args.args[0].get_full_url() == "https://gitlab.example.com/runners"


### PR DESCRIPTION
Refactors the script to support multiple gitlab instances.  As before, the
prefix argument points to our runner's eventual config.toml.  Now the templates
argument points to a directory of toml files, one per runner.  Runner toml
files are processed as before, but admin and access tokens need to be provided
per runner as each runner could use a different gitlab url.  Admin/access
tokens are not however persisted in the final config.toml generated.