### PR TITLE
Add a script to package with zipapp

### DIFF
--- a/package
+++ b/package
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+[[ -d build ]] && rm -rf build
+mkdir -p build
+cp gitlab_runner_config.py build/__main__.py
+cp requirements.txt build/
+pushd .
+  cd build
+  python3 -m pip install -t $PWD -r requirements.txt
+popd
+python3 -m zipapp build -p "/usr/bin/env python3" -o register-runner
+chmod +x register-runner

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+python-gitlab==2.6.0


### PR DESCRIPTION
This takes all dependencies and the script and packages
everything as an executable zip file. This enables use
on systems where the default python may be missing
required packages.